### PR TITLE
Archive the required agent

### DIFF
--- a/sports_analyzer/requirements.txt
+++ b/sports_analyzer/requirements.txt
@@ -1,14 +1,3 @@
 requests>=2.28.0
 schedule>=1.2.0
 anthropic>=0.7.0
-asyncio
-logging
-unicodedata
-difflib
-re
-json
-datetime
-typing
-math
-os
-sys


### PR DESCRIPTION
Remove built-in Python modules from `requirements.txt` to fix dependency installation errors.

The `requirements.txt` file incorrectly listed several built-in Python modules (e.g., `unicodedata`, `json`, `os`) as dependencies, causing `pip install` to fail. Removing these entries allows the project dependencies to be installed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-167309b4-6fc0-451f-91b8-5a0a25f807c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-167309b4-6fc0-451f-91b8-5a0a25f807c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

